### PR TITLE
Fix chart cache

### DIFF
--- a/lib/charts.js
+++ b/lib/charts.js
@@ -10,7 +10,10 @@ function ChartController(options) {
   this.node = options.node;
   this.blocks = options.blocks;
 
-  this.chartCache = LRU(options.chartCacheSize || ChartController.DEFAULT_CHART_CACHE_SIZE);
+  this.chartCache = LRU({
+      max: options.chartCacheSize || ChartController.DEFAULT_CHART_CACHE_SIZE,
+      maxAge: 1000 * 150
+  });
 
   this.common = new Common({log: this.node.log});
 }


### PR DESCRIPTION
There is a bug in the chart which causes insight to cache the chart data on first hit, then never update it again. This adjustment caches the data for the block time, allowing the chart to remain up-to-date.